### PR TITLE
Fix curl calls accidents and entropy/set

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Randomly generates Prometheus metrics for simulating default /metrics endpoints 
 1. **Build**
 
 ```
-docker-comopse build
+docker-compose build
 ```
 
 2. **Run**
@@ -28,36 +28,42 @@ If you want to cause any resource metric to behave abnormaly, you could:
 
 ### 1. Cause latency accidents 
 ```
-curl -X POST http://localhost:32865/accidents
-{
-	"resourcename": "/resource/test-0001",
-	"type": "latency",
-	"value": "100"
-}
+curl http://localhost:32865/accidents \
+     --header "Content-Type: application/json" \
+     --request POST \
+     --data "{
+         \"resourcename\": \"/resource/test-0001\",
+         \"type\": \"latency\",
+         \"value\": 100
+     }";
 ```
 
 * Which will cause the requests time counter to the resource `/resource/test-0001` to have a median duration of 100ms
 
 ### 2. Cause request count accidents
 ```
-curl -X POST http://localhost:32865/accidents
-{
-	"resourcename": "/resource/test-0001",
-	"type": "calls",
-	"value": "100"
-}
+curl http://localhost:32865/accidents \
+     --header "Content-Type: application/json" \
+     --request POST \
+     --data "{
+         \"resourcename\": \"/resource/test-0001\",
+         \"type\": \"calls\",
+         \"value\": 100
+     }";
 ```
 
 * Which will cause the request count to the resource `/resource/test-0001` to increase by a factor of 100
 
 ### 3. Cause error rate accidents
 ```
-curl -X POST http://localhost:32865/accidents
-{
-	"resourcename": "/resource/test-0001",
-	"type": "errorrate",
-	"value": "0.7"
-}
+curl http://localhost:32865/accidents \
+     --header "Content-Type: application/json" \
+     --request POST \
+     --data "{
+         \"resourcename\": \"/resource/test-0001\",
+         \"type\": \"errorrate\",
+         \"value\": 100
+     }";
 ```
 
 * Which will cause the error rate associated with the resource `/resource/test-0001` to float around 70%
@@ -76,13 +82,15 @@ By default, this generator simulates requests to 10 different URIs, 2 different 
 Via the `/entropy/set` endpoint you can control this numbers resulting in how many samples are collected each time.
 
 ```
-curl - X POST http://localhost:32865/entropy/set
-{
-	"uricount": 20,
-	"serviceversioncount": 2,
-	"appversioncount": 2,
-	"devicecount": 2
-}
+ curl http://localhost:32865/entropy/set \
+      --header "Content-Type: application/json"
+      --request POST \
+      --data "{
+         \"uricount\": 20,
+         \"serviceversioncount\": 2,
+         \"appversioncount\": 2,
+         \"devicecount\": 2
+      }";
 ```
 
 * This request will cause the generator to simulate requests to 20 different URIs


### PR DESCRIPTION
The `curl` examples were not working properly.